### PR TITLE
fix:  missing monday in home page week chart

### DIFF
--- a/core/util/src/main/kotlin/com/titi/app/core/util/JavaTimeUtil.kt
+++ b/core/util/src/main/kotlin/com/titi/app/core/util/JavaTimeUtil.kt
@@ -69,8 +69,8 @@ fun areDatesInSameMonth(localDate: LocalDate, zonedDateTime: ZonedDateTime): Boo
 
 fun areDatesInSameWeek(localDate: LocalDate, zonedDateTime: ZonedDateTime): Boolean {
     val (monday, sunday) = getMondaySunday(localDate)
-
-    return zonedDateTime.isAfter(monday) && zonedDateTime.isBefore(sunday)
+   
+    return  (zonedDateTime.isEqual(monday) || zonedDateTime.isAfter(monday)) && zonedDateTime.isBefore(sunday)
 }
 
 fun areDatesInSameDay(localDate: LocalDate, zonedDateTime: ZonedDateTime): Boolean {


### PR DESCRIPTION
Update JavaTimeUtil.kt

I noticed that Monday's data is missing on the week chart of the home log page , so I think the bug might be here.
I tried to fix it, but I haven’t fully tested the solution yet.🤔
By the way, I really love this amazing and beautiful app, great work! 🥰🥰